### PR TITLE
fix: resolve API URL without downloading full AppImage

### DIFF
--- a/.github/badges/beeper-version.json
+++ b/.github/badges/beeper-version.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "Beeper Latest",
-  "message": "4.2.630",
+  "message": "4.2.653",
   "color": "blue"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.1] - 2026-03-17
+
+### Fixed
+
+- **API version check timeout** — The curl call followed the API redirect (`-L`) and started downloading the ~200MB AppImage to `/dev/null`, always timing out (exit code 28) on slower connections
+- **Version extraction false positives** — Fallback regex could match semver patterns in CDN domain/path prefixes (e.g., `cdn-v3.example.com`); now restricted to filename via `basename`
+
+### Changed
+
+- **Progressive URL resolution** — Replaced single curl call with 3-strategy fallback:
+  1. **HEAD request** — reads Location header without following redirect (~0.7s)
+  2. **Range 0-0** — follows redirects, requests 1 byte only (~1.0s)
+  3. **Full GET** — last resort with `--max-filesize 1MB` bandwidth cap (~10s)
+- **`set -e` safety** — All curl calls in version check now have `|| true` to prevent silent failures during future refactoring
+- **Case-insensitive header parsing** — Location header extraction handles all case forms (`Location:`, `location:`, `LOCATION:`)
+
+### Performance
+
+| Metric | Before | After |
+|--------|--------|-------|
+| Version check | 30s timeout → exit 28 | **0.7s** → success |
+| Full script to prereqs | Never reached | **4.1s** |
+
 ## [1.8.0] - 2026-03-09
 
 ### Added
@@ -220,6 +243,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 (No unreleased changes)
+
+[1.8.1]: https://github.com/beeper-community/update-beeper/releases/tag/v1.8.1
 
 ## [1.0.0] - 2026-01-16
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: Roberto Gogoni <your-email@example.com>
 
 pkgname=update-beeper
-pkgver=1.8.0
+pkgver=1.8.1
 pkgrel=1
 pkgdesc="Self-healing Beeper Desktop updater for Arch Linux with automatic rollback"
 arch=('any')

--- a/checksums.sha256
+++ b/checksums.sha256
@@ -5,7 +5,7 @@
 # Generated automatically by GitHub Actions on each release
 # Manual generation: sha256sum update-beeper beeper-version beeper-health install.sh > checksums.sha256
 
-c543d4c0d46caa107c511450f48e000488626759b5045915b02e22d031801c9e  update-beeper
+82c452f91c82d03da6966c98d20e8837b10dbe215695ba5347bb0f5b0a77e194  update-beeper
 e0d05fd668f71823f8ec052e028eec14fa1512d517809ac7ea8b3e13c47038fd  beeper-version
 089a5ae14b63f7aade976cc6b3e0b6d27eda2cf18180e2152401094e02616984  beeper-health
 8256006580a8c9ae03235af1c0a78a2fff908a9662372892201bb14d6df94a1b  install.sh

--- a/update-beeper
+++ b/update-beeper
@@ -472,29 +472,57 @@ check_versions() {
         INSTALLED=$(pacman -Q beeper-v4-bin 2>/dev/null | awk '{print $2}' | cut -d'-' -f1)
     fi
 
-    # Get latest version from API (SINGLE curl call for both status + URL)
-    # Sets globals: DOWNLOAD_URL, LATEST, AUR
-    local api_response
-    api_response=$(curl -Ls -m 10 -o /dev/null -w "%{http_code}\n%{url_effective}" "$BEEPER_API" 2>/dev/null)
-    local http_status
-    http_status=$(echo "$api_response" | head -1)
-    DOWNLOAD_URL=$(echo "$api_response" | tail -1)
+    # Resolve latest version from Beeper API redirect chain.
+    # The API returns a 302 redirect to a CDN URL with the version in the filename.
+    # We use progressive strategies to get that URL without downloading the ~200MB AppImage.
+    # Each strategy is faster but less compatible; fallback ensures resilience.
+    DOWNLOAD_URL=""
+    LATEST="unknown"
 
-    if [[ "$http_status" != "200" ]] && [[ "$http_status" != "302" ]] && [[ "$http_status" != "301" ]]; then
-        echo -e "${ERR}    ✗ Beeper API returned HTTP $http_status${NC}" >&2
+    # Strategy 1: HEAD request — get Location header without following redirect (~0.7s)
+    # HTTP-correct: zero body transfer. Only works for single-hop redirects;
+    # the Beeper-* guard safely rejects intermediate URLs if multi-hop.
+    local headers
+    headers=$(curl -sI -m 10 "$BEEPER_API" 2>/dev/null) || true
+    if [[ -n "$headers" ]]; then
+        local location
+        location=$(echo "$headers" | grep -i '^location:' | head -1 | sed -E 's/^[^:]+:[[:space:]]*//' | tr -d '\r\n')
+        if [[ -n "$location" && "$location" == *"Beeper-"* ]]; then
+            DOWNLOAD_URL="$location"
+        fi
+    fi
+
+    # Strategy 2: GET with Range 0-0 — follow redirects, request 1 byte (~1s)
+    # Needed if the API returns 200 instead of 302, or if HEAD is blocked by CDN.
+    if [[ -z "$DOWNLOAD_URL" ]]; then
+        local range_url
+        range_url=$(curl -Ls -m 10 -r 0-0 -o /dev/null -w "%{url_effective}" "$BEEPER_API" 2>/dev/null) || true
+        if [[ -n "$range_url" && "$range_url" == *"Beeper-"* ]]; then
+            DOWNLOAD_URL="$range_url"
+        fi
+    fi
+
+    # Strategy 3: Full GET with tight timeout — last resort (~10s max, bandwidth-capped)
+    if [[ -z "$DOWNLOAD_URL" ]]; then
+        local full_url
+        full_url=$(curl -Ls -m 10 --max-filesize 1048576 -o /dev/null -w "%{url_effective}" "$BEEPER_API" 2>/dev/null) || true
+        if [[ -n "$full_url" && "$full_url" == *"Beeper-"* ]]; then
+            DOWNLOAD_URL="$full_url"
+        fi
+    fi
+
+    # Extract version from resolved URL (filename only to avoid CDN path false positives)
+    if [[ -n "$DOWNLOAD_URL" ]]; then
+        LATEST=$(basename "$DOWNLOAD_URL" | grep -oP 'Beeper-\K[0-9]+\.[0-9]+\.[0-9]+')
+        if [[ -z "$LATEST" ]]; then
+            LATEST=$(basename "$DOWNLOAD_URL" | grep -oP '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+        fi
+    fi
+
+    if [[ -z "$DOWNLOAD_URL" || -z "$LATEST" ]]; then
+        echo -e "${ERR}    ✗ Could not resolve Beeper download URL${NC}" >&2
         LATEST="unknown"
         DOWNLOAD_URL=""
-    else
-        LATEST=$(echo "$DOWNLOAD_URL" | grep -oP 'Beeper-\K[0-9]+\.[0-9]+\.[0-9]+')
-
-        # Validate LATEST extraction - if empty, API redirect may have failed
-        if [[ -z "$LATEST" ]]; then
-            # Try alternative: extract from any version pattern in URL
-            LATEST=$(echo "$DOWNLOAD_URL" | grep -oP '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-        fi
-        if [[ -z "$LATEST" ]]; then
-            LATEST="unknown"
-        fi
     fi
 
     # Get AUR version via JSON RPC API (structured, no HTML scraping)

--- a/update-beeper
+++ b/update-beeper
@@ -4,7 +4,7 @@
 
 set -e
 
-SCRIPT_VERSION="1.8.0"
+SCRIPT_VERSION="1.8.1"
 LOCKFILE="/tmp/update-beeper.lock"
 BEEPER_API="https://api.beeper.com/desktop/download/linux/x64/stable/com.automattic.beeper.desktop"
 CHANGELOG_URL="https://www.beeper.com/changelog/desktop"


### PR DESCRIPTION
## Summary

- Version check was timing out (exit 28) because `curl -Ls -o /dev/null` followed the API redirect and started downloading the ~200MB AppImage
- Replaced with a **3-strategy progressive fallback** that resolves the CDN URL without transferring the file body
- Also hardened version extraction and `set -e` safety

## Root Cause

The Beeper API at `/desktop/download/linux/x64/stable/...` returns a **302 redirect** to the CDN. The original code used `curl -Ls -m 10 -o /dev/null -w "%{url_effective}"` which:
1. Follows the redirect (`-L`)
2. Gets a **200** from the CDN
3. Starts downloading the **~200MB AppImage** to `/dev/null`
4. Hits the 10-second timeout → **exit code 28**

## Fix: Progressive URL Resolution

| Strategy | Method | Speed | When Used |
|----------|--------|-------|-----------|
| 1. HEAD | `curl -sI` — reads Location header | ~0.7s | Primary (HTTP-correct, zero body transfer) |
| 2. Range | `curl -Ls -r 0-0` — requests 1 byte | ~1.0s | Fallback if HEAD blocked or no redirect |
| 3. Full GET | `curl -Ls --max-filesize 1MB` — capped | ~10s | Last resort (bandwidth-limited) |

Each strategy validates the URL contains `Beeper-` before accepting it (guards against intermediate redirect URLs).

## Additional Fixes

- **Version extraction** now uses `basename` to avoid matching semver patterns in CDN domain/path prefixes
- **`|| true`** on all curl calls for explicit `set -e` safety
- **Location header parsing** handles all case variations (`Location:`, `location:`, `LOCATION:`)

## Test Results

```
Strategy 1 (HEAD - no follow):   4.2.653  — 0.718s
Strategy 2 (Range 0-0 - follow): 4.2.653  — 0.991s
Strategy 3 (Full GET - follow):  4.2.653  — 10.012s
Full script to version check:    4.2.653  — 4.077s (was: timeout/exit 28)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)